### PR TITLE
gitignore any subfolders named xcuserdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .build
+xcuserdata/


### PR DESCRIPTION
The first thing I noticed after opening the project (using Xcode) was the creation of two folders

- Mimus.xcodeproj/project.xcworkspace/xcuserdata/
- Mimus.xcodeproj/xcuserdata/

This would just be noise for others, so let's have git ignore them.