### PR TITLE
Added more advanced info about comparison result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: Swift
 xcode_project: Mimus.xcodeproj
 xcode_scheme: MimusTests
-xcode_sdk: [iphonesimulator10.2]
-osx_image: xcode8.2
+xcode_sdk: [iphonesimulator11.0]
+osx_image: xcode9.0
 
 script:
   - ./run_tests.sh

--- a/Mimus/Source/Matcher.swift
+++ b/Mimus/Source/Matcher.swift
@@ -1,35 +1,69 @@
+internal struct MatchResult {
+
+    struct MismatchedComparison {
+
+        let expected: MockEquatable?
+
+        let actual: MockEquatable?
+    }
+
+    let matching: Bool
+
+    let mismatchedComparisons: [MismatchedComparison]
+
+    init(matching: Bool) {
+        self.matching = matching
+        self.mismatchedComparisons = []
+    }
+
+    init(matching: Bool, mismatchedComparisons: [MismatchedComparison]) {
+        self.matching = matching
+        self.mismatchedComparisons = mismatchedComparisons
+    }
+}
+
 internal class Matcher {
 
-    func match(expected: [MockEquatable?]?, actual: [MockEquatable?]?) -> Bool {
+    func match(expected: [MockEquatable?]?, actual: [MockEquatable?]?) -> MatchResult {
         if expected == nil && actual == nil {
-            return true
+            return MatchResult(matching: true)
         }
 
         guard let expectedArguments = expected, let actualArguments = actual else {
-            return false
+            return MatchResult(matching: false)
         }
 
         if expectedArguments.count != actualArguments.count {
-            return false
+            return MatchResult(matching: false)
         }
 
         return match(expectedArguments: expectedArguments, actualArguments: actualArguments)
     }
 
-    func match(expectedArguments: [MockEquatable?], actualArguments: [MockEquatable?]) -> Bool {
+    func match(expectedArguments: [MockEquatable?], actualArguments: [MockEquatable?]) -> MatchResult {
         // At this point we're sure both arrays have the same count
 
         var equal = true
 
+        var mismatchedComparisons: [MatchResult.MismatchedComparison] = []
+
         for (index, item) in expectedArguments.enumerated() {
+            let internalEqual: Bool
+
             let other = actualArguments[index]
             if let unwrappedItem = item {
-                equal = (unwrappedItem.equalTo(other: other)) && equal
+                internalEqual = (unwrappedItem.equalTo(other: other))
             } else {
-                equal = other == nil
+                internalEqual = other == nil
             }
+
+            if !internalEqual {
+                mismatchedComparisons.append(MatchResult.MismatchedComparison(expected: item, actual: other))
+            }
+
+            equal = internalEqual && equal
         }
 
-        return equal
+        return MatchResult(matching: equal, mismatchedComparisons: mismatchedComparisons)
     }
 }

--- a/Mimus/Source/Mock.swift
+++ b/Mimus/Source/Mock.swift
@@ -69,20 +69,15 @@ public extension Mock {
         let callCandidates = storage.filter {
             $0.identifier == callIdentifier
         }
-        var matchCount = 0
-        var differentArgumentsMatchCount = 0
 
-        for candidate in callCandidates {
-            if mockMatcher.match(expected: arguments, actual: candidate.arguments) {
-                matchCount += 1
-            } else {
-                differentArgumentsMatchCount += 1
-            }
-        }
+        let matchResults = callCandidates.map({ mockMatcher.match(expected: arguments, actual: $0.arguments) })
+
+        let matchedResults = matchResults.filter({ $0.matching })
+        let mismatchedResults = matchResults.filter({ !$0.matching })
 
         VerificationHandler.shared.verifyCall(callIdentifier: callIdentifier,
-            matchCount: matchCount,
-            differentArgumentsMatchCount: differentArgumentsMatchCount,
+            matchedResults: matchedResults,
+            mismatchedArgumentsResults: mismatchedResults,
             mode: mode,
             testLocation: testLocation)
 

--- a/Mimus/Source/Verification/VerificationHandler.swift
+++ b/Mimus/Source/Verification/VerificationHandler.swift
@@ -8,24 +8,24 @@ internal class VerificationHandler {
 
     static var shared: VerificationHandler = VerificationHandler()
 
-    func verifyCall(callIdentifier: String, matchCount: Int, differentArgumentsMatchCount: Int, mode: VerificationMode, testLocation: TestLocation) {
+    func verifyCall(callIdentifier: String, matchedResults: [MatchResult], mismatchedArgumentsResults: [MatchResult], mode: VerificationMode, testLocation: TestLocation) {
         switch mode {
         case .never:
             assertNever(callIdentifier: callIdentifier,
-                    matchCount: matchCount,
-                    differentArgumentsMatchCount: differentArgumentsMatchCount,
+                    matchCount: matchedResults.count,
+                    differentArgumentsMatchCount: mismatchedArgumentsResults.count,
                     testLocation: testLocation)
         case .atLeast(let count):
             assertAtLeast(callIdentifier: callIdentifier,
                     times: count,
-                    matchCount: matchCount,
-                    differentArgumentsMatchCount: differentArgumentsMatchCount,
+                    matchCount: matchedResults.count,
+                    differentArgumentsMatchCount: mismatchedArgumentsResults.count,
                     testLocation: testLocation)
         case .times(let count):
             assert(callIdentifier: callIdentifier,
                     times: count,
-                    matchCount: matchCount,
-                    differentArgumentsMatchCount: differentArgumentsMatchCount,
+                    matchCount: matchedResults.count,
+                    differentArgumentsMatchCount: mismatchedArgumentsResults.count,
                     testLocation: testLocation)
         }
     }

--- a/MimusTests/FoundationMatcherTests.swift
+++ b/MimusTests/FoundationMatcherTests.swift
@@ -26,7 +26,8 @@ class MatcherTests: XCTestCase {
         let actual: NSString = "Fixture String"
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected strings to match")
+        XCTAssertTrue(result.matching, "Expected strings to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testStaticStringFailingInvocation() {
@@ -34,7 +35,11 @@ class MatcherTests: XCTestCase {
         let actual: NSString = "Another Fixture String"
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected strings not to match")
+        XCTAssertFalse(result.matching, "Expected strings not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
+
+        let mismatchedResult = result.mismatchedComparisons[0]
+        mismatchedResult.assert(expected: expected, actual: actual)
     }
 
     func testStaticStringWithNSStringPassingInvocation() {
@@ -42,7 +47,8 @@ class MatcherTests: XCTestCase {
         let actual: NSString = "Fixture String"
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected strings to match")
+        XCTAssertTrue(result.matching, "Expected strings to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testStaticStringWithNSStringFailingInvocation() {
@@ -50,7 +56,8 @@ class MatcherTests: XCTestCase {
         let actual: NSString = "Another Fixture String"
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected strings not to match")
+        XCTAssertFalse(result.matching, "Expected strings not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
     }
 
     func testStringWithNSStringPassingInvocation() {
@@ -58,7 +65,8 @@ class MatcherTests: XCTestCase {
         let actual: NSString = "Fixture String"
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected strings to match")
+        XCTAssertTrue(result.matching, "Expected strings to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testStringWithNSStringFailingInvocation() {
@@ -66,7 +74,11 @@ class MatcherTests: XCTestCase {
         let actual: NSString = "Another Fixture String"
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected strings not to match")
+        XCTAssertFalse(result.matching, "Expected strings not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
+
+        let mismatchedResult = result.mismatchedComparisons[0]
+        mismatchedResult.assert(expected: expected, actual: actual)
     }
 
     // MARK: NSNumber
@@ -76,7 +88,8 @@ class MatcherTests: XCTestCase {
         let actual: NSNumber = 42
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected NSNumbers to match")
+        XCTAssertTrue(result.matching, "Expected NSNumbers to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testNSNumberFailingInvocation() {
@@ -84,7 +97,11 @@ class MatcherTests: XCTestCase {
         let actual: NSNumber = 43
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected NSNumbers not to match")
+        XCTAssertFalse(result.matching, "Expected NSNumbers not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
+
+        let mismatchedResult = result.mismatchedComparisons[0]
+        mismatchedResult.assert(expected: expected, actual: actual)
     }
 
     // MARK: NSError
@@ -94,7 +111,8 @@ class MatcherTests: XCTestCase {
         let actual = NSError(domain: "Fixture Domain", code: 42)
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected NSErrors to match")
+        XCTAssertTrue(result.matching, "Expected NSErrors to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testNSErrorFailingInvocation() {
@@ -102,7 +120,11 @@ class MatcherTests: XCTestCase {
         let actual = NSError(domain: "Fixture Domain", code: 43)
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected NSErrors not to match")
+        XCTAssertFalse(result.matching, "Expected NSErrors not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
+
+        let mismatchedResult = result.mismatchedComparisons[0]
+        mismatchedResult.assert(expected: expected, actual: actual)
     }
 
     // MARK: NSURL
@@ -112,7 +134,8 @@ class MatcherTests: XCTestCase {
         let actual = NSURL(string: "https://fixture.url.com/fixture/suffix")!
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected NSErrors to match")
+        XCTAssertTrue(result.matching, "Expected NSErrors to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testNSURLFailingInvocation() {
@@ -120,7 +143,11 @@ class MatcherTests: XCTestCase {
         let actual = NSURL(string: "https://fixture.url.eu/fixture/suffix")!
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected NSErrors not to match")
+        XCTAssertFalse(result.matching, "Expected NSErrors not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
+
+        let mismatchedResult = result.mismatchedComparisons[0]
+        mismatchedResult.assert(expected: expected, actual: actual)
     }
 
     // MARK: NSArray
@@ -130,7 +157,8 @@ class MatcherTests: XCTestCase {
         let actual = NSArray(objects: NSString(string: "Fixture String"), NSNumber(floatLiteral: 0.5))
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected arrays to match")
+        XCTAssertTrue(result.matching, "Expected arrays to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testNSArrayFailingInvocation() {
@@ -138,7 +166,8 @@ class MatcherTests: XCTestCase {
         let actual = NSArray(objects: NSString(string: "Fixture String"), NSNumber(floatLiteral: 0.5))
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected arrays not to match")
+        XCTAssertFalse(result.matching, "Expected arrays not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
     }
 
     func testIncompatibleSizesNSArrayFailingInvocation() {
@@ -146,7 +175,8 @@ class MatcherTests: XCTestCase {
         let actual = NSArray(objects: NSString(string: "Fixture String"), NSNumber(floatLiteral: 0.5))
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected arrays not to match")
+        XCTAssertFalse(result.matching, "Expected arrays not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
     }
 
     func testNestedNSArrayPassingInvocation() {
@@ -156,7 +186,8 @@ class MatcherTests: XCTestCase {
         let actual = NSArray(objects: NSNumber(floatLiteral: 0.5), nestedActualArray)
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected arrays to match")
+        XCTAssertTrue(result.matching, "Expected arrays to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testNestedNSArrayFailingInvocation() {
@@ -166,7 +197,8 @@ class MatcherTests: XCTestCase {
         let actual = NSArray(objects: NSNumber(floatLiteral: 0.5), nestedActualArray)
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected arrays not to match")
+        XCTAssertFalse(result.matching, "Expected arrays not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
     }
 
     // MARK: NSDictionary
@@ -176,7 +208,8 @@ class MatcherTests: XCTestCase {
         let actual = NSDictionary(dictionaryLiteral: (NSString(string: "Fixture Key 1"), NSString(string: "Fixture Value")), (NSString(string: "Fixture Key 2"), NSNumber(floatLiteral: 0.5)))
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected dictionaries to match")
+        XCTAssertTrue(result.matching, "Expected dictionaries to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testNSDictionaryFailingInvocation() {
@@ -184,7 +217,8 @@ class MatcherTests: XCTestCase {
         let actual = NSDictionary(dictionaryLiteral: (NSString(string: "Fixture Key 2"), NSString(string: "Fixture Value")), (NSString(string: "Fixture Key 1"), NSNumber(floatLiteral: 0.5)))
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected dictionaries not to match")
+        XCTAssertFalse(result.matching, "Expected dictionaries not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
     }
 
     func testIncompatibleSizesNSDictionaryFailingInvocation() {
@@ -192,7 +226,8 @@ class MatcherTests: XCTestCase {
         let actual = NSDictionary(dictionaryLiteral: (NSString(string: "Fixture Key 2"), NSString(string: "Fixture Value")), (NSString(string: "Fixture Key 1"), NSNumber(floatLiteral: 0.5)))
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected dictionaries not to match")
+        XCTAssertFalse(result.matching, "Expected dictionaries not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
     }
 
     func testNestedNSDictionaryPassingInvocation() {
@@ -202,7 +237,8 @@ class MatcherTests: XCTestCase {
         let actual = NSDictionary(dictionaryLiteral: (NSString(string: "Fixture Key 1"), nestedActualDictionary))
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected dictionaries to match")
+        XCTAssertTrue(result.matching, "Expected dictionaries to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testNestedNSDictionaryFailingInvocation() {
@@ -212,7 +248,8 @@ class MatcherTests: XCTestCase {
         let actual = NSDictionary(dictionaryLiteral: (NSString(string: "Fixture Key 1"), nestedActualDictionary), (NSString(string: "Fixture Key 2"), nestedExpectedDictionary))
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected dictionaries not to match")
+        XCTAssertTrue(result.matching, "Expected dictionaries to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     // MARK: More Complicated Scenarios
@@ -223,11 +260,12 @@ class MatcherTests: XCTestCase {
         let expected = NSArray(objects: NSString(string: "Fixture String"), NSNull(), NSNumber(integerLiteral: 42), NSNumber(floatLiteral: 1.0), nestedArray, nestedDictionary)
         let actual = NSArray(objects: NSString(string: "Fixture String"), NSNull(), NSNumber(integerLiteral: 42), NSNumber(floatLiteral: 1.0), nestedArray, nestedDictionary)
         let result = matcher.match(
-                expected: [expected],
-                actual: [actual]
+            expected: [expected],
+            actual: [actual]
         )
 
-        XCTAssertTrue(result, "Expected elements to match")
+        XCTAssertTrue(result.matching, "Expected elements to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testFailingInvocation() {
@@ -236,10 +274,11 @@ class MatcherTests: XCTestCase {
         let expected = NSArray(objects: NSString(string: "Fixture String"), NSNull(), NSNumber(integerLiteral: 42), NSNumber(floatLiteral: 1.0), nestedArray, nestedDictionary)
         let actual = NSArray(objects: NSString(string: "Fixture String"), NSNull(), nestedArray, nestedDictionary)
         let result = matcher.match(
-                expected: [expected],
-                actual: [actual]
+            expected: [expected],
+            actual: [actual]
         )
 
-        XCTAssertFalse(result, "Expected elements to match")
+        XCTAssertFalse(result.matching, "Expected elements to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
     }
 }

--- a/MimusTests/Helpers/TestExtensions.swift
+++ b/MimusTests/Helpers/TestExtensions.swift
@@ -3,6 +3,7 @@
 //
 
 import Foundation
+import XCTest
 
 @testable import Mimus
 
@@ -22,3 +23,10 @@ public func ==(lhs: VerificationMode, rhs: VerificationMode) -> Bool {
     }
 }
 
+extension MatchResult.MismatchedComparison {
+
+    func assert<T: Equatable, M: Equatable>(expected: T?, actual: M?, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(actual, self.actual as? M, file: file, line: line)
+        XCTAssertEqual(expected, self.expected as? T, file: file, line: line)
+    }
+}

--- a/MimusTests/MatcherTests.swift
+++ b/MimusTests/MatcherTests.swift
@@ -24,12 +24,13 @@ class FoundationMatcherTests: XCTestCase {
 
     func testStringPassingInvocation() {
         let result = matcher.match(expected: ["Fixture String"], actual: ["Fixture String"])
-        XCTAssertTrue(result, "Expected strings to match")
+        XCTAssertTrue(result.matching, "Expected strings to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testStringFailingInvocation() {
         let result = matcher.match(expected: ["Fixture String"], actual: ["Fixture Another String"])
-        XCTAssertFalse(result, "Expected strings not to match")
+        XCTAssertFalse(result.matching, "Expected strings not to match")
     }
 
     func testStaticStringPassingInvocation() {
@@ -37,7 +38,8 @@ class FoundationMatcherTests: XCTestCase {
         let actual: StaticString = "Fixture String"
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected strings to match")
+        XCTAssertTrue(result.matching, "Expected strings to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testStaticStringFailingInvocation() {
@@ -45,7 +47,7 @@ class FoundationMatcherTests: XCTestCase {
         let actual: StaticString = "Another Fixture String"
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected strings not to match")
+        XCTAssertFalse(result.matching, "Expected strings not to match")
     }
 
     func testStaticStringWithStringPassingInvocation() {
@@ -53,7 +55,8 @@ class FoundationMatcherTests: XCTestCase {
         let actual = "Fixture String"
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result, "Expected strings to match")
+        XCTAssertTrue(result.matching, "Expected strings to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testStaticStringWithStringFailingInvocation() {
@@ -61,49 +64,53 @@ class FoundationMatcherTests: XCTestCase {
         let actual = "Another Fixture String"
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertFalse(result, "Expected strings not to match")
+        XCTAssertFalse(result.matching, "Expected strings not to match")
     }
 
     // MARK: Basic Types
 
     func testIntPassingInvocation() {
         let result = matcher.match(expected: [42], actual: [42])
-        XCTAssertTrue(result, "Expected ints to match")
+        XCTAssertTrue(result.matching, "Expected ints to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testIntFailingInvocation() {
         let result = matcher.match(expected: [42], actual: [43])
-        XCTAssertFalse(result, "Expected ints not to match")
+        XCTAssertFalse(result.matching, "Expected ints not to match")
     }
 
     func testDoublePassingInvocation() {
         let result = matcher.match(expected: [42.0], actual: [42.0])
-        XCTAssertTrue(result, "Expected doubles to match")
+        XCTAssertTrue(result.matching, "Expected doubles to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testDoubleFailingInvocation() {
         let result = matcher.match(expected: [42.0], actual: [43.0])
-        XCTAssertFalse(result, "Expected doubles not to match")
+        XCTAssertFalse(result.matching, "Expected doubles not to match")
     }
 
     func testFloatPassingInvocation() {
         let result = matcher.match(expected: [Float(42.0)], actual: [Float(42.0)])
-        XCTAssertTrue(result, "Expected floats to match")
+        XCTAssertTrue(result.matching, "Expected floats to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testFloatFailingInvocation() {
         let result = matcher.match(expected: [Float(42.0)], actual: [Float(43.0)])
-        XCTAssertFalse(result, "Expected floats not to match")
+        XCTAssertFalse(result.matching, "Expected floats not to match")
     }
 
     func testBoolPassingInvocation() {
         let result = matcher.match(expected: [true], actual: [true])
-        XCTAssertTrue(result, "Expected booleans to match")
+        XCTAssertTrue(result.matching, "Expected booleans to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testBoolFailingInvocation() {
         let result = matcher.match(expected: [true], actual: [false])
-        XCTAssertFalse(result, "Expected booleans not to match")
+        XCTAssertFalse(result.matching, "Expected booleans not to match")
     }
 
     // MARK: Index Paths
@@ -113,7 +120,8 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [IndexPath(row: 42, section: 43)],
                 actual: [IndexPath(row: 42, section: 43)]
         )
-        XCTAssertTrue(result, "Expected index paths to match")
+        XCTAssertTrue(result.matching, "Expected index paths to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testIndexPathFailingInvocation() {
@@ -121,14 +129,14 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [IndexPath(row: 42, section: 43)],
                 actual: [IndexPath(row: 44, section: 43)]
         )
-        XCTAssertFalse(result, "Expected index paths not to match")
+        XCTAssertFalse(result.matching, "Expected index paths not to match")
     }
 
     // MARK: Different Types
 
     func testIncorrectTypes() {
         let result = matcher.match(expected: [42.0], actual: ["Fixture String"])
-        XCTAssertFalse(result, "Expected incorrect not to match")
+        XCTAssertFalse(result.matching, "Expected incorrect not to match")
     }
 
     // MARK: Url
@@ -138,7 +146,8 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [URL(string: "https://fixture.url.com/fixture/suffix")!],
                 actual: [URL(string: "https://fixture.url.com/fixture/suffix")!]
         )
-        XCTAssertTrue(result, "Expected urls to match")
+        XCTAssertTrue(result.matching, "Expected urls to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testUrlFailingInvocation() {
@@ -146,7 +155,7 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [URL(string: "https://fixture.url.com/fixture/suffix")!],
                 actual: [URL(string: "https://fixture.url.eu/fixture/suffix")!]
         )
-        XCTAssertFalse(result, "Expected urls not to match")
+        XCTAssertFalse(result.matching, "Expected urls not to match")
     }
     
     func testUrlCrossTypePassingInvocation() {
@@ -154,19 +163,21 @@ class FoundationMatcherTests: XCTestCase {
             expected: [URL(string: "https://fixture.url.com/fixture/suffix")!, NSURL(string: "https://fixture.url.pl/fixture/suffix")!],
             actual: [NSURL(string: "https://fixture.url.com/fixture/suffix")!, URL(string: "https://fixture.url.pl/fixture/suffix")!]
         )
-        XCTAssertTrue(result, "Expected urls to match")
+        XCTAssertTrue(result.matching, "Expected urls to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     // MARK: Working with optionals and nil
 
     func testNilPassingInvocation() {
         let result = matcher.match(expected: [nil], actual: [nil])
-        XCTAssertTrue(result, "Expected nils to match")
+        XCTAssertTrue(result.matching, "Expected nils to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testNilFailingInvocation() {
         let result = matcher.match(expected: [nil], actual: [42])
-        XCTAssertFalse(result, "Expected elements not to match")
+        XCTAssertFalse(result.matching, "Expected elements not to match")
     }
 
     // MARK: Arrays
@@ -176,7 +187,8 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [["Fixture Value 1", "Fixture Value 2"]],
                 actual: [["Fixture Value 1", "Fixture Value 2"]]
         )
-        XCTAssertTrue(result, "Expected arrays to match")
+        XCTAssertTrue(result.matching, "Expected arrays to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testArrayFailingInvocation() {
@@ -184,7 +196,7 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [["Fixture Value 1", "Fixture Value 2"]],
                 actual: [["Fixture Value 1", "Another Fixture Value 2"]]
         )
-        XCTAssertFalse(result, "Expected arrays not to match")
+        XCTAssertFalse(result.matching, "Expected arrays not to match")
     }
 
     func testIncompatibleSizesArrayFailingInvocation() {
@@ -192,7 +204,7 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [["Fixture Value 1", "Fixture Value 2", "Fixture Value 3"]],
                 actual: [["Fixture Value 1", "Fixture Value 2"]]
         )
-        XCTAssertFalse(result, "Expected arrays not to match")
+        XCTAssertFalse(result.matching, "Expected arrays not to match")
     }
 
     func testNestedArraysPassingInvocation() {
@@ -200,7 +212,8 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [["Fixture Value 1", "Fixture Value 2", ["Fixture Value 3"]]],
                 actual: [["Fixture Value 1", "Fixture Value 2", ["Fixture Value 3"]]]
         )
-        XCTAssertTrue(result, "Expected arrays to match")
+        XCTAssertTrue(result.matching, "Expected arrays to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testNestedArraysFailingInvocation() {
@@ -208,7 +221,7 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [["Fixture Value 1", "Fixture Value 2", ["Fixture Value 3"]]],
                 actual: [["Fixture Value 1", "Fixture Value 2", ["Fixture Value 4"]]]
         )
-        XCTAssertFalse(result, "Expected arrays not to match")
+        XCTAssertFalse(result.matching, "Expected arrays not to match")
     }
 
     // MARK: Dictionaries
@@ -218,7 +231,8 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [["Fixture Key": "Fixture Value"]],
                 actual: [["Fixture Key": "Fixture Value"]]
         )
-        XCTAssertTrue(result, "Expected dictionary to match")
+        XCTAssertTrue(result.matching, "Expected dictionary to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testDictionaryFailingInvocationDifferentKeys() {
@@ -226,7 +240,7 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [["Fixture Key": "Fixture Value"]],
                 actual: [["Another Fixture Key": "Fixture Value"]]
         )
-        XCTAssertFalse(result, "Expected dictionary not to match")
+        XCTAssertFalse(result.matching, "Expected dictionary not to match")
     }
 
     func testDictionaryFailingInvocationDifferentValues() {
@@ -234,7 +248,7 @@ class FoundationMatcherTests: XCTestCase {
                 expected: [["Fixture Key": "Fixture Value"]],
                 actual: [["Fixture Key": "Another Fixture Value"]]
         )
-        XCTAssertFalse(result, "Expected dictionary not to match")
+        XCTAssertFalse(result.matching, "Expected dictionary not to match")
     }
 
     // MARK: More Complicated Scenarios
@@ -245,7 +259,8 @@ class FoundationMatcherTests: XCTestCase {
                 actual: ["Fixture String", nil, 42, 1.0, ["Key": "Value"], ["Fixture Element", URL(string: "htp://fixture/url")!]]
         )
 
-        XCTAssertTrue(result, "Expected elements to match")
+        XCTAssertTrue(result.matching, "Expected elements to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
     }
 
     func testFailingInvocation() {
@@ -254,6 +269,14 @@ class FoundationMatcherTests: XCTestCase {
                 actual: ["Fixture String", nil, 42, 1.0, ["Another Key": "Value"], ["Fixture Another Element"]]
         )
 
-        XCTAssertFalse(result, "Expected elements to match")
+        XCTAssertFalse(result.matching, "Expected elements to not match")
+    }
+
+    // MARK: Bugs
+
+    func testNilValues() {
+        let result = matcher.match(expected: ["Fixture Value", nil], actual: ["Fixture Another value", nil])
+
+        XCTAssertFalse(result.matching, "Expected elements to not match")
     }
 }

--- a/MimusTests/MockTests.swift
+++ b/MimusTests/MockTests.swift
@@ -5,19 +5,18 @@
 import XCTest
 @testable import Mimus
 
-
 class FakeVerificationHandler: VerificationHandler {
 
     var lastCallIdentifier: String?
-    var lastMatchCount: Int?
-    var lastDifferentArgumentsCount: Int?
+    var lastMatchedResults: [MatchResult]?
+    var lastMismatchedArgumentsResults: [MatchResult]?
     var lastMode: VerificationMode?
     var lastTestLocation: TestLocation?
 
-    override func verifyCall(callIdentifier: String, matchCount: Int, differentArgumentsMatchCount: Int, mode: VerificationMode, testLocation: TestLocation) {
+    override func verifyCall(callIdentifier: String, matchedResults: [MatchResult], mismatchedArgumentsResults: [MatchResult], mode: VerificationMode, testLocation: TestLocation) {
         lastCallIdentifier = callIdentifier
-        lastMatchCount = matchCount
-        lastDifferentArgumentsCount = differentArgumentsMatchCount
+        lastMatchedResults = matchedResults
+        lastMismatchedArgumentsResults = mismatchedArgumentsResults
         lastTestLocation = testLocation
         lastMode = mode
     }
@@ -87,7 +86,7 @@ class MockTests: XCTestCase {
 
         mockRecorder.verifyCall(withIdentifier: "Fixture Identifier")
 
-        XCTAssertEqual(fakeVerificationHandler.lastMatchCount, 2, "Expected verification handler to receive correct number of matches")
+        XCTAssertEqual(fakeVerificationHandler.lastMatchedResults?.count, 2, "Expected verification handler to receive correct number of matches")
     }
 
     func testCorrectNumberOfMatchesWithArguments() {
@@ -98,7 +97,7 @@ class MockTests: XCTestCase {
 
         mockRecorder.verifyCall(withIdentifier: "Fixture Identifier", arguments: [42, 43])
 
-        XCTAssertEqual(fakeVerificationHandler.lastMatchCount, 2, "Expected verification handler to receive correct number of matches")
+        XCTAssertEqual(fakeVerificationHandler.lastMatchedResults?.count, 2, "Expected verification handler to receive correct number of matches")
     }
 
     func testCorrectNumberOfMismatchedArguments() {
@@ -108,8 +107,8 @@ class MockTests: XCTestCase {
 
         mockRecorder.verifyCall(withIdentifier: "Fixture Identifier", arguments: [42])
 
-        XCTAssertEqual(fakeVerificationHandler.lastMatchCount, 1, "Expected verification handler to receive correct number of matches")
-        XCTAssertEqual(fakeVerificationHandler.lastDifferentArgumentsCount, 2, "Expected verification handler to receive correct number of unmatched arguments")
+        XCTAssertEqual(fakeVerificationHandler.lastMatchedResults?.count, 1, "Expected verification handler to receive correct number of matches")
+        XCTAssertEqual(fakeVerificationHandler.lastMismatchedArgumentsResults?.count, 2, "Expected verification handler to receive correct number of unmatched arguments")
     }
 
     func testCaptureArgument() {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-xcodebuild test -project "Mimus.xcodeproj" -scheme "Mimus" -destination "name=iPad Air,OS=10.2" | xcpretty --test
+xcodebuild test -project "Mimus.xcodeproj" -scheme "Mimus" -destination "name=iPad Air" | xcpretty --test


### PR DESCRIPTION
This paves way for better failure messages, e.g. what were the expected and actual values.

This also fixes issue with incorrect comparison result being calculated if last values used for comparison were nils. 