### PR TITLE
Record values as `Any` rather than `MockEquatable`

### DIFF
--- a/Mimus.podspec
+++ b/Mimus.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Mimus"
-  s.version      = "1.0.1"
+  s.version      = "1.0.2"
   s.summary      = "Swift Mocking Library"
 
   s.description  = <<-DESC

--- a/Mimus.xcodeproj/project.pbxproj
+++ b/Mimus.xcodeproj/project.pbxproj
@@ -298,21 +298,24 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0820;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0910;
 				ORGANIZATIONNAME = AirHelp;
 				TargetAttributes = {
 					10115C271E6DA39B0001E9A2 = {
 						CreatedOnToolsVersion = 8.2;
+						LastSwiftMigration = 0910;
 						ProvisioningStyle = Manual;
 					};
 					10115C301E6DA39B0001E9A2 = {
 						CreatedOnToolsVersion = 8.2;
 						DevelopmentTeam = PDY79HZ4XW;
+						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
 					10539B571E7BF218006EA51F = {
 						CreatedOnToolsVersion = 8.2;
 						DevelopmentTeam = PDY79HZ4XW;
+						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -425,7 +428,9 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
@@ -433,7 +438,11 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -478,7 +487,9 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
@@ -486,7 +497,11 @@
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
@@ -540,7 +555,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.Mimus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -569,7 +585,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.Mimus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -581,7 +598,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.MimusTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -593,7 +611,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.MimusTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -605,7 +624,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.MimusExamples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -617,7 +637,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.airhelp.MimusExamples;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Mimus.xcodeproj/xcshareddata/xcschemes/Mimus.xcscheme
+++ b/Mimus.xcodeproj/xcshareddata/xcschemes/Mimus.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0910"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -65,6 +66,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Mimus.xcodeproj/xcshareddata/xcschemes/MimusTests.xcscheme
+++ b/Mimus.xcodeproj/xcshareddata/xcschemes/MimusTests.xcscheme
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0910"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForTesting = "YES">
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "10115C301E6DA39B0001E9A2"
@@ -23,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -43,12 +47,22 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "10115C301E6DA39B0001E9A2"
+            BuildableName = "MimusTests.xctest"
+            BlueprintName = "MimusTests"
+            ReferencedContainer = "container:Mimus.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Mimus/Source/Matcher.swift
+++ b/Mimus/Source/Matcher.swift
@@ -4,7 +4,7 @@ internal struct MatchResult {
 
         let expected: MockEquatable?
 
-        let actual: MockEquatable?
+        let actual: Any?
     }
 
     let matching: Bool
@@ -24,7 +24,7 @@ internal struct MatchResult {
 
 internal class Matcher {
 
-    func match(expected: [MockEquatable?]?, actual: [MockEquatable?]?) -> MatchResult {
+    func match(expected: [MockEquatable?]?, actual: [Any?]?) -> MatchResult {
         if expected == nil && actual == nil {
             return MatchResult(matching: true)
         }
@@ -40,7 +40,7 @@ internal class Matcher {
         return match(expectedArguments: expectedArguments, actualArguments: actualArguments)
     }
 
-    func match(expectedArguments: [MockEquatable?], actualArguments: [MockEquatable?]) -> MatchResult {
+    func match(expectedArguments: [MockEquatable?], actualArguments: [Any?]) -> MatchResult {
         // At this point we're sure both arrays have the same count
 
         var equal = true

--- a/Mimus/Source/Matchers/AnyMatcher.swift
+++ b/Mimus/Source/Matchers/AnyMatcher.swift
@@ -6,7 +6,7 @@ public class AnyMatcher: MockEquatable {
     public init() {
     }
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         return true
     }
 }

--- a/Mimus/Source/Matchers/CaptureArgumentMatcher.swift
+++ b/Mimus/Source/Matchers/CaptureArgumentMatcher.swift
@@ -7,8 +7,8 @@ public class CaptureArgumentMatcher: MockEquatable {
     public init() {
     }
 
-    public func equalTo(other: MockEquatable?) -> Bool {
-        capturedValues.append(other as Any)
+    public func equalTo(other: Any?) -> Bool {
+        capturedValues.append(other)
         return true
     }
 }

--- a/Mimus/Source/Matchers/FoundationMatchers.swift
+++ b/Mimus/Source/Matchers/FoundationMatchers.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension NSError: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         if let otherError = other as? NSError {
             return self == otherError
         }
@@ -12,7 +12,7 @@ extension NSError: MockEquatable {
 
 extension NSString: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         let selfSwiftString = self as String
         return selfSwiftString.equalTo(other: other)
     }
@@ -20,7 +20,7 @@ extension NSString: MockEquatable {
 
 extension NSNumber: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         if let otherNumber = other as? NSNumber {
             return self == otherNumber
         }
@@ -30,7 +30,7 @@ extension NSNumber: MockEquatable {
 
 extension NSArray: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         if let array = self as? Array<Any> {
             return array.equalTo(other: other)
         } else {
@@ -41,7 +41,7 @@ extension NSArray: MockEquatable {
 
 extension NSDictionary: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         if let dictionary = self as? Dictionary<AnyHashable, Any> {
             return dictionary.equalTo(other: other)
         } else {
@@ -52,14 +52,14 @@ extension NSDictionary: MockEquatable {
 
 extension NSNull: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         return other == nil || other is NSNull
     }
 }
 
 extension NSURL: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         let selfSwiftUrl = self as URL
         return selfSwiftUrl.equalTo(other: other)
     }

--- a/Mimus/Source/Matchers/SwiftMatchers.swift
+++ b/Mimus/Source/Matchers/SwiftMatchers.swift
@@ -6,7 +6,7 @@ import XCTest
 
 extension String: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         if let otherString = other as? String {
             return self == otherString
         }
@@ -19,7 +19,7 @@ extension String: MockEquatable {
 
 extension StaticString: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         let selfString = self.toString()
         if let otherString = other as? String {
             return selfString == otherString
@@ -40,7 +40,7 @@ extension StaticString: MockEquatable {
 
 extension Int: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         if let otherInt = other as? Int {
             return self == otherInt
         }
@@ -50,7 +50,7 @@ extension Int: MockEquatable {
 
 extension Float: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         if let otherFloat = other as? Float {
             return self == otherFloat
         }
@@ -60,7 +60,7 @@ extension Float: MockEquatable {
 
 extension Double: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         if let otherDouble = other as? Double {
             return self == otherDouble
         }
@@ -70,7 +70,7 @@ extension Double: MockEquatable {
 
 extension Bool: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         if let otherBool = other as? Bool {
             return self == otherBool
         }
@@ -80,7 +80,7 @@ extension Bool: MockEquatable {
 
 extension URL: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         if let otherUrl = other as? URL {
             return self == otherUrl
         }
@@ -90,7 +90,7 @@ extension URL: MockEquatable {
 
 extension Array: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         // Small hack to go around type system
         let selfAny = self as Any?
         guard let selfArray = selfAny as? [MockEquatable?],
@@ -135,7 +135,7 @@ extension Array: MockEquatable {
 
 extension Dictionary: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         // Small hack to go around type system
         let anySelf: [AnyHashable: Any] = self
         let anyOther = other as? [AnyHashable: Any]
@@ -165,7 +165,7 @@ extension Dictionary: MockEquatable {
 
 extension IndexPath: MockEquatable {
 
-    public func equalTo(other: MockEquatable?) -> Bool {
+    public func equalTo(other: Any?) -> Bool {
         if let otherIndexPath = other as? IndexPath {
             return self == otherIndexPath
         }

--- a/Mimus/Source/Mock.swift
+++ b/Mimus/Source/Mock.swift
@@ -20,7 +20,7 @@ public protocol MockEquatable {
     ///
     /// - Parameter other: other value for verifying equality
     /// - Returns: true if values are equal, false if not
-    func equalTo(other: MockEquatable?) -> Bool
+    func equalTo(other: Any?) -> Bool
 }
 
 /// Structure used to hold recorded invocations
@@ -28,7 +28,7 @@ public struct RecordedCall {
 
     let identifier: String
 
-    let arguments: [MockEquatable?]?
+    let arguments: [Any?]?
 
 }
 
@@ -47,7 +47,7 @@ public extension Mock {
     /// - Parameters:
     ///   - callIdentifier: call identifier for recorded invocation. You should use the same identifier when verifying call.
     ///   - arguments: Recorded arguments. You can pass nil if no arguments are needed. Supports nils in the array as well.
-    func recordCall(withIdentifier callIdentifier: String, arguments: [MockEquatable?]? = nil) {
+    func recordCall(withIdentifier callIdentifier: String, arguments: [Any?]? = nil) {
         let record = RecordedCall(identifier: callIdentifier, arguments: arguments)
         storage.append(record)
     }

--- a/MimusTests/MatcherExtensionsTests.swift
+++ b/MimusTests/MatcherExtensionsTests.swift
@@ -37,7 +37,7 @@ class MatcherExtensionsTests: XCTestCase {
 
 extension User: MockEquatable {
 
-    func equalTo(other: MockEquatable?) -> Bool {
+    func equalTo(other: Any?) -> Bool {
         return compare(other: other as? User)
     }
 }


### PR DESCRIPTION
This allows for a more versatile approach. For instance, you don't need to conform to `MockEquatable` to use `AnyMatcher` or `CaptureArgumentMatcher`. This will also enable nicer usage of `InstanceMatcher` once it's implemented. 