### PR TITLE
Check dictionaries keys in default Dictionary matcher

### DIFF
--- a/Mimus/Source/Matchers/SwiftMatchers.swift
+++ b/Mimus/Source/Matchers/SwiftMatchers.swift
@@ -148,6 +148,10 @@ extension Dictionary: MockEquatable {
             return false
         }
 
+        guard keys.count == actual.keys.count else {
+            return false
+        }
+
         var equal = true
 
         for (key, expectedValue) in expected {

--- a/MimusTests/FoundationMatcherTests.swift
+++ b/MimusTests/FoundationMatcherTests.swift
@@ -248,8 +248,8 @@ class MatcherTests: XCTestCase {
         let actual = NSDictionary(dictionaryLiteral: (NSString(string: "Fixture Key 1"), nestedActualDictionary), (NSString(string: "Fixture Key 2"), nestedExpectedDictionary))
 
         let result = matcher.match(expected: [expected], actual: [actual])
-        XCTAssertTrue(result.matching, "Expected dictionaries to match")
-        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
+        XCTAssertFalse(result.matching, "Expected dictionaries not to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 1, "Expected one mismatched results")
     }
 
     // MARK: More Complicated Scenarios

--- a/MimusTests/MatcherTests.swift
+++ b/MimusTests/MatcherTests.swift
@@ -251,6 +251,14 @@ class FoundationMatcherTests: XCTestCase {
         XCTAssertFalse(result.matching, "Expected dictionary not to match")
     }
 
+    func testDictionaryWithDifferentAmountOfValues() {
+        let result = matcher.match(
+            expected: [["Fixture Key": "Fixture Value"]],
+            actual: [["Fixture Key": "Fixture Value", "Second Fixture Key": "Fixture Value"]]
+        )
+        XCTAssertFalse(result.matching, "Expected dictionary not to match")
+    }
+
     // MARK: More Complicated Scenarios
 
     func testPassingInvocation() {


### PR DESCRIPTION
Mimus didn't have that much, and it could lead to successfully matching dictionaries with subset of equal keys, not all.