### PR TITLE
Allow to specify any or none arguments for matching

### DIFF
--- a/Mimus/Source/Matcher.swift
+++ b/Mimus/Source/Matcher.swift
@@ -24,23 +24,30 @@ internal struct MatchResult {
 
 internal class Matcher {
 
-    func match(expected: [MockEquatable?]?, actual: [Any?]?) -> MatchResult {
-        if expected == nil && actual == nil {
+    func match(expected: Arguments, actual: [Any?]?) -> MatchResult {
+        switch expected {
+        case .any:
             return MatchResult(matching: true)
+        case .none:
+            return MatchResult(matching: actual == nil)
+        case let .actual(arguments):
+            return match(expected: arguments, actual: actual)
         }
-
-        guard let expectedArguments = expected, let actualArguments = actual else {
-            return MatchResult(matching: false)
-        }
-
-        if expectedArguments.count != actualArguments.count {
-            return MatchResult(matching: false)
-        }
-
-        return match(expectedArguments: expectedArguments, actualArguments: actualArguments)
     }
 
-    func match(expectedArguments: [MockEquatable?], actualArguments: [Any?]) -> MatchResult {
+    private func match(expected: [MockEquatable?], actual: [Any?]?) -> MatchResult {
+        guard let actualArguments = actual else {
+            return MatchResult(matching: false)
+        }
+
+        if expected.count != actualArguments.count {
+            return MatchResult(matching: false)
+        }
+
+        return match(expectedArguments: expected, actualArguments: actualArguments)
+    }
+
+    private func match(expectedArguments: [MockEquatable?], actualArguments: [Any?]) -> MatchResult {
         // At this point we're sure both arrays have the same count
 
         var equal = true

--- a/Mimus/Source/Mock.swift
+++ b/Mimus/Source/Mock.swift
@@ -12,6 +12,18 @@ public enum VerificationMode {
     case times(Int)
 }
 
+public enum Arguments: ExpressibleByArrayLiteral {
+    case any
+    case actual([MockEquatable?])
+    case none
+    
+    public init(arrayLiteral elements: MockEquatable?...) {
+        self = .actual(elements)
+    }
+    
+    public typealias ArrayLiteralElement = MockEquatable?
+}
+
 /// Protocol used for verifying equality between objects. Mimus delivers support for base Swift types, check out
 /// https://github.com/AirHelp/Mimus/blob/master/Documentation/Using%20Your%20Own%20Types.md if you want to use your own types
 public protocol MockEquatable {
@@ -25,23 +37,17 @@ public protocol MockEquatable {
 
 /// Structure used to hold recorded invocations
 public struct RecordedCall {
-
     let identifier: String
-
     let arguments: [Any?]?
-
 }
 
 /// Use this protocol to add mocking functionality for your mock objects. You will have to provide storage for recorded 
 /// calls in your implementation.
 public protocol Mock: class {
-
     var storage: [RecordedCall] { get set }
-
 }
 
 public extension Mock {
-
     /// Records given invocation.
     ///
     /// - Parameters:
@@ -61,7 +67,7 @@ public extension Mock {
     ///   - mode: Verification mode. Defaults to .times(1)
     ///   - file: The file where your verification happens. Defaults to file where given call was made.
     ///   - line: The line where your verification happens. Defaults to line where given call was made.
-    func verifyCall(withIdentifier callIdentifier: String, arguments: [MockEquatable?]? = nil, mode: VerificationMode = .times(1), file: StaticString = #file, line: UInt = #line) {
+    func verifyCall(withIdentifier callIdentifier: String, arguments: Arguments = .none, mode: VerificationMode = .times(1), file: StaticString = #file, line: UInt = #line) {
         let testLocation = TestLocation(file: file, line: line)
         TestLocation.internalTestLocation = testLocation
         let mockMatcher = Matcher()

--- a/MimusTests/MatcherTests.swift
+++ b/MimusTests/MatcherTests.swift
@@ -280,6 +280,49 @@ class FoundationMatcherTests: XCTestCase {
         XCTAssertFalse(result.matching, "Expected elements to not match")
     }
 
+    // Mark: None Tests
+
+    func testAnyInvocation() {
+        let result = matcher.match(
+            expected: .any,
+            actual: ["Fixture String", nil, 42, 1.0, ["Key": "Value"], ["Fixture Element", URL(string: "htp://fixture/url")!]]
+        )
+
+        XCTAssertTrue(result.matching, "Expected elements to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
+    }
+
+    func testAnyNoArgumentsInvocation() {
+        let result = matcher.match(
+            expected: .any,
+            actual: nil
+        )
+
+        XCTAssertTrue(result.matching, "Expected elements to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
+    }
+
+    func testNoneNoArgumentsInvocation() {
+        let result = matcher.match(
+            expected: .none,
+            actual: nil
+        )
+
+        XCTAssertTrue(result.matching, "Expected elements to match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
+    }
+
+    func testNoneInvocation() {
+        let result = matcher.match(
+            expected: .none,
+            actual: ["Fixture String", nil, 42, 1.0, ["Key": "Value"], ["Fixture Element", URL(string: "htp://fixture/url")!]]
+        )
+        
+        XCTAssertFalse(result.matching, "Expected elements to not match")
+        XCTAssertEqual(result.mismatchedComparisons.count, 0, "Expected no mismatched results")
+    }
+
+
     // MARK: Bugs
 
     func testNilValues() {


### PR DESCRIPTION
This provides a backwards compatible implementation for #22 using `ExpressibleByArrayLiteral`.